### PR TITLE
コマンドパレットをタイトルより前面に表示

### DIFF
--- a/src/components/commandPalette/CommandPaletteUI.tsx
+++ b/src/components/commandPalette/CommandPaletteUI.tsx
@@ -122,6 +122,7 @@ const Wrapper = styled.form`
   transform: translateX(-50%);
   background-color: #252526;
   color: #fff;
+  z-index: 1;
 `
 const Head = styled.div`
   height: ${HEAD_HEIGHT}px;


### PR DESCRIPTION
#  やったこと

- コマンドパレットをタイトルより前面に表示
   - Before
      - <img width="1120" alt="Screen Shot 2020-02-09 at 13 41 29" src="https://user-images.githubusercontent.com/38120991/74096573-0d3a3800-4b44-11ea-8dd5-34a6a8235375.png">
  - After
    - <img width="1118" alt="Screen Shot 2020-02-09 at 13 48 44" src="https://user-images.githubusercontent.com/38120991/74096581-19be9080-4b44-11ea-9b90-0b728a96fee4.png">
- `z-index` で調整するのがいいのかちょっとわからないです 🤔 