### PR TITLE
タブレット・スマホ対応のための便利関数を作成

### DIFF
--- a/src/components/parts/SectionTitle.tsx
+++ b/src/components/parts/SectionTitle.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
 import styled, { css } from 'styled-components'
+import { mediaQuery } from '../../themes'
 
 type Props = {
   backgroundText: string
@@ -52,5 +53,9 @@ const Title = styled.h2<{ backgroundText: string }>`
       opacity: 0.4;
       transform: rotate(-7deg);
     }
+
+    ${mediaQuery.mediumStyle(css`
+      font-size: 36px;
+    `)}
   `}
 `

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,0 +1,1 @@
+export { mediaQuery } from './size'

--- a/src/themes/size.ts
+++ b/src/themes/size.ts
@@ -1,0 +1,9 @@
+import { FlattenSimpleInterpolation } from 'styled-components'
+
+const mediumMaxWidth = 1199
+const smallMaxWidth = 740
+
+export const mediaQuery = {
+  mediumStyle: (style: FlattenSimpleInterpolation) => `@media screen and (max-width: ${mediumMaxWidth}px) {${style}}`,
+  smallStyle: (style: FlattenSimpleInterpolation) => `@media screen and (max-width: ${smallMaxWidth}px) {${style}}`,
+}

--- a/src/themes/size.ts
+++ b/src/themes/size.ts
@@ -1,7 +1,7 @@
 import { FlattenSimpleInterpolation } from 'styled-components'
 
 const mediumMaxWidth = 1199
-const smallMaxWidth = 740
+const smallMaxWidth = 739
 
 export const mediaQuery = {
   mediumStyle: (style: FlattenSimpleInterpolation) => `@media screen and (max-width: ${mediumMaxWidth}px) {${style}}`,


### PR DESCRIPTION
タブレット・スマホへのレスポンシブ対応のための styled-components の styled 内で使える関数を用意しました。

こんな感じで使います。

```
${mediaQuery.mediumStyle(css`
  font-size: 36px;
`)}
```

mediumStyle, smallStyle 内に styled-components の css 関数を隠蔽しても良かったのですが styled-components の syntax highlight がそのまま使えた方が良いかなとという考えの元、 css 関数は mediumStyle, smallStyle を使う側で引数に入れてもらうようにしました。

最初に PC のコーディングをしているので、 PC ファーストで特定のサイズ以下になったらスタイルを追加で付与する、という形にしていく想定です。なので、現状は PC サイズのみ指定するスタイル、のようなことはできません。進めていく中でそれが必要になりそうなシーンがあれば追加するという形で考えています。

- 全サイズ適用のスタイル
- innerWidth が1199px以下のスタイル
- innerWidth が 739px以下でのスタイル

という感じになっています。
2つの数字に関しては、 inVision を見ながら横幅を狭めていって破綻しそうなところで切り替わるように、というところで選びました。

試しに SectionTitle の font-size をタブレットサイズ用に切り替えるスタイルを入れています。