### PR TITLE
messageセクションのモバイル調整

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,8 @@
 import React, { FC, ReactNode } from 'react'
-import { createGlobalStyle } from 'styled-components'
+import { createGlobalStyle, css } from 'styled-components'
 import reset from 'styled-reset'
 
+import { mediaQuery } from '../themes'
 import { CommandPaletteProvider, commands } from './commandPalette'
 
 export const App: FC<{ children: ReactNode }> = ({ children }) => (
@@ -27,6 +28,10 @@ const GlobalStyle = createGlobalStyle`
   }
   img {
     vertical-align: middle;
+
+    ${mediaQuery.mediumStyle(css`
+      width: 100%;
+    `)}
   }
   input, button, textarea {
     margin: 0;

--- a/src/components/parts/EntrySection.tsx
+++ b/src/components/parts/EntrySection.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { SectionTitle } from './SectionTitle'
+import { mediaQuery } from '../../themes'
 
 export const EntrySection = () => {
   return (
@@ -51,6 +52,10 @@ const Wrapper = styled.div`
   margin-bottom: 55px;
   width: 869px;
   justify-content: space-between;
+
+  ${mediaQuery.mediumStyle(css`
+    width: 100%;
+  `)}
 `
 
 const Message = styled.p`
@@ -62,6 +67,10 @@ const Message = styled.p`
   letter-spacing: 2.25px;
   line-height: 48.6px;
   margin-bottom: 36px;
+
+  ${mediaQuery.mediumStyle(css`
+    width: 100%;
+  `)}
 `
 
 const List = styled.ul`
@@ -87,6 +96,11 @@ const Item = styled.a`
   font-size: 14px;
   font-weight: bold;
   letter-spacing: 0.69px;
+
+  ${mediaQuery.mediumStyle(css`
+    width: 100%;
+  `)}
+
   &::after {
     position: absolute;
     content: '';

--- a/src/components/parts/MembersVoiceSection.tsx
+++ b/src/components/parts/MembersVoiceSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
+import { mediaQuery } from '../../themes'
 import { SectionTitle } from './SectionTitle'
 import { Accordion } from './Accordion'
 
@@ -133,6 +134,10 @@ const Wrapper = styled.section`
 const AcoordionWrapper = styled.div`
   margin: 140px 0 0 auto;
   width: 867px;
+
+  ${mediaQuery.mediumStyle(css`
+    width: 100%;
+  `)}
 
   & > dl {
     &:not(:first-of-type) {

--- a/src/components/parts/MessageSection.tsx
+++ b/src/components/parts/MessageSection.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+
+import { mediaQuery } from '../../themes'
 
 export const MessageSection = () => (
   <Wrapper>
@@ -20,11 +22,29 @@ export const MessageSection = () => (
 
 const Wrapper = styled.section`
   padding: 285px 0 115px;
+
+  ${mediaQuery.mediumStyle(css`
+    padding: 140px 0 0;
+  `)}
+
+  ${mediaQuery.smallStyle(css`
+    padding: 72px 0 0;
+  `)}
 `
 
 const TextWrapper = styled.div`
   width: 640px;
   margin: 0 auto;
+
+  ${mediaQuery.mediumStyle(css`
+    width: 500px;
+  `)}
+
+  ${mediaQuery.smallStyle(css`
+    width: 100%;
+    padding: 0 40px;
+    box-sizing: border-box;
+  `)}
 `
 
 const Text = styled.p`
@@ -32,4 +52,12 @@ const Text = styled.p`
   font-size: 18px;
   padding-top: 50px;
   line-height: 72px;
+
+  ${mediaQuery.mediumStyle(css`
+    font-size: 14px;
+  `)}
+
+  ${mediaQuery.smallStyle(css`
+    font-size: 18px;
+  `)}
 `

--- a/src/components/parts/TechnologyStackSection.tsx
+++ b/src/components/parts/TechnologyStackSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
+import { mediaQuery } from '../../themes'
 import { SectionTitle } from './SectionTitle'
 
 export const TechnologyStackSection = () => {
@@ -61,6 +62,10 @@ const ChildSection = styled.section`
   padding-top: 130px;
   width: 570px;
   margin: 0 auto;
+
+  ${mediaQuery.mediumStyle(css`
+    width: 100%;
+  `)}
 `
 
 const ChildSectionTitle = styled.h3`

--- a/src/components/parts/WelfareSection.tsx
+++ b/src/components/parts/WelfareSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
+import { mediaQuery } from '../../themes'
 import { SectionTitle } from './SectionTitle'
 
 export const WelfareSection = () => {
@@ -73,6 +74,10 @@ const List = styled.ul`
   margin-bottom: 55px;
   width: 869px;
   justify-content: space-between;
+
+  ${mediaQuery.mediumStyle(css`
+    width: 100%;
+  `)}
 `
 
 const Item = styled.li`
@@ -124,5 +129,9 @@ const LinkButton = styled.a`
   font-size: 22px;
   font-weight: bold;
   letter-spacing: 0.85px;
+
+  ${mediaQuery.mediumStyle(css`
+    width: 100%;
+  `)}
 `
 const Icon = styled.span``


### PR DESCRIPTION
## What

- messageセクションのモバイル調整
- mobile調整しやすいように画像や幅に`width: 100%`を指定（mobile調整後削除します。）

[Tablet design](https://smarthr.invisionapp.com/d/main#/console/18984751/397682813/preview)
[SP design](https://smarthr.invisionapp.com/d/main#/console/18984751/397682812/preview)

## Screenshots

<details>
  <summary>Tablet</summary>

![image](https://user-images.githubusercontent.com/23610884/79537008-4949c600-80bc-11ea-9293-39a92a1afe8e.png)
</details>

<details>
  <summary>SP</summary>

![image](https://user-images.githubusercontent.com/23610884/79537098-88781700-80bc-11ea-940b-321999462167.png)
</details>


