### PR TITLE
バックグラウンドイメージとスクロールアニメーションアイコンの調整

### DIFF
--- a/src/components/hooks/useEventListener.ts
+++ b/src/components/hooks/useEventListener.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react'
+
+export const useEventListener = <T extends Event>(
+  eventName: string,
+  handler: (e: T) => void,
+  element: Element | Window = window,
+) => {
+  const savedHandler = useRef<(e: T) => void>()
+
+  useEffect(() => {
+    savedHandler.current = handler
+  }, [handler])
+
+  useEffect(() => {
+    const eventListener = (e: T) => {
+      savedHandler.current && savedHandler.current(e)
+    }
+
+    element.addEventListener(eventName, eventListener as any)
+
+    return () => {
+      element.removeEventListener(eventName, eventListener as any)
+    }
+  }, [eventName, element])
+}

--- a/src/components/hooks/useStoredScroll.ts
+++ b/src/components/hooks/useStoredScroll.ts
@@ -1,0 +1,13 @@
+import { useCallback, useState } from 'react'
+import { useEventListener } from './useEventListener'
+
+export const useStoredScroll = () => {
+  const [y, setY] = useState(scrollY)
+  const handleScroll = useCallback(() => {
+    setY(scrollY)
+  }, [])
+
+  useEventListener('scroll', handleScroll)
+
+  return { y }
+}

--- a/src/components/pages/index.tsx
+++ b/src/components/pages/index.tsx
@@ -1,8 +1,8 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext } from 'react'
 import styled, { css, keyframes } from 'styled-components'
 
-import { CommandPaletteContext } from '../commandPalette'
 import { mediaQuery } from '../../themes'
+import { CommandPaletteContext } from '../commandPalette'
 
 import { MessageSection } from '../parts/MessageSection'
 import { AboutSection } from '../parts/AboutSection'
@@ -11,26 +11,16 @@ import { MembersVoiceSection } from '../parts/MembersVoiceSection'
 import { WelfareSection } from '../parts/WelfareSection'
 import { EntrySection } from '../parts/EntrySection'
 import { Footer } from '../parts/Footer'
+import { EyeCatchEffects } from '../parts/EyeCatchEffects'
 
 export const IndexPage = () => {
   const { currentCommand } = useContext(CommandPaletteContext)
 
-  const [scrolled, setScrolled] = useState(false)
-
-  useEffect(() => {
-    document.addEventListener('scroll', () => {
-      if (scrollY >= innerHeight / 3) {
-        setScrolled(true)
-      } else {
-        setScrolled(false)
-      }
-    })
-  }, [])
-
   return (
     <Wrapper>
-      <Underlay scrolled={scrolled} />
       {currentCommand && currentCommand.component}
+
+      <EyeCatchEffects />
 
       <Contents>
         {/* TODO: Headerコンポーネント化する */}
@@ -45,6 +35,7 @@ export const IndexPage = () => {
             <EntryButton href="">ENTRY</EntryButton>
           </Right>
         </Header>
+
         <Sections>
           {/* TODO: EyecatchSectionコンポーネント化する */}
           <EyecatchSection>
@@ -62,7 +53,7 @@ export const IndexPage = () => {
           <WelfareSection />
           <EntrySection />
         </Sections>
-        <ScrollIcon>SCROLL</ScrollIcon>
+
         <Footer />
       </Contents>
     </Wrapper>
@@ -71,28 +62,6 @@ export const IndexPage = () => {
 
 const Wrapper = styled.div`
   position: relative;
-`
-const Underlay = styled.div`
-  ${({ scrolled }) => {
-    return css`
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      background-image: url(/images/mv.png);
-      background-size: cover;
-      background-attachment: fixed;
-      background-position: top;
-      opacity: ${scrolled ? '0.4' : '1'};
-      transition: opacity 0.3s ease-in-out;
-
-      ${mediaQuery.smallStyle(css`
-        background-image: url(/images/mv_sp.png);
-        background-size: 100% 100%;
-      `)}
-    `
-  }}
 `
 const Contents = styled.div`
   position: relative;
@@ -206,57 +175,4 @@ const Sections = styled.div`
 `
 const EyecatchSection = styled.section`
   height: 100vh;
-`
-const scroll = keyframes`
-  0% {
-    bottom: 80px;
-    height: 0px;
-  }
-
-  40% {
-    bottom: 0px;
-    height: 80px;
-  }
-
-  60% {
-    bottom: 0px;
-    height: 80px;
-  }
-
-  100% {
-    bottom: 0px;
-    height: 0px;
-  }
-`
-const ScrollIcon = styled.div`
-  position: fixed;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 10px;
-  height: 104px;
-  color: #e1e1e1;
-  &::before {
-    display: block;
-    bottom: 0;
-    content: '';
-    position: absolute;
-    width: 1px;
-    height: 80px;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: #797979;
-  }
-  &::after {
-    display: block;
-    bottom: 56px;
-    content: '';
-    position: absolute;
-    width: 3px;
-    height: 0px;
-    animation: ${scroll} 1s infinite ease-in;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: #ebebeb;
-  }
 `

--- a/src/components/parts/EyeCatchEffects.tsx
+++ b/src/components/parts/EyeCatchEffects.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled, { css, keyframes } from 'styled-components'
 
-import { mediaQuery } from '../../themes'
+import { isMediumWindow, mediaQuery } from '../../themes'
 import { useStoredScroll } from '../hooks/useStoredScroll'
 
 const MIN_OPACITY = 0.4
@@ -38,19 +38,16 @@ export const EyeCatchEffects = () => {
 }
 
 const scroll = keyframes`
-  0% {
-    bottom: 80px;
+  0%,
+  30% {
+    bottom: ${isMediumWindow() ? 59 : 80}px;
     height: 0px;
   }
 
-  40% {
+  60%,
+  70% {
     bottom: 0px;
-    height: 80px;
-  }
-
-  60% {
-    bottom: 0px;
-    height: 80px;
+    height: ${isMediumWindow() ? 59 : 80}px;
   }
 
   100% {
@@ -87,6 +84,7 @@ const ScrollIcon = styled.div`
   font-size: 10px;
   height: 104px;
   color: #e1e1e1;
+
   &::before {
     display: block;
     bottom: 0;
@@ -98,16 +96,29 @@ const ScrollIcon = styled.div`
     transform: translateX(-50%);
     background-color: #797979;
   }
+
   &::after {
     display: block;
     bottom: 56px;
     content: '';
     position: absolute;
-    width: 3px;
+    width: 2px;
     height: 0px;
-    animation: ${scroll} 1s infinite ease-in;
     left: 50%;
     transform: translateX(-50%);
     background-color: #ebebeb;
+    animation: ${scroll} 2s infinite;
   }
+
+  ${mediaQuery.mediumStyle(css`
+    height: 83px;
+
+    &::before {
+      height: 59px;
+    }
+
+    &::after {
+      bottom: 35px;
+    }
+  `)}
 `

--- a/src/components/parts/EyeCatchEffects.tsx
+++ b/src/components/parts/EyeCatchEffects.tsx
@@ -32,7 +32,7 @@ export const EyeCatchEffects = () => {
   return (
     <>
       <Underlay opacity={opacity} />
-      <ScrollIcon>SCROLL</ScrollIcon>
+      <ScrollIcon visible={y < innerHeight / 2}>SCROLL</ScrollIcon>
     </>
   )
 }
@@ -76,49 +76,56 @@ const Underlay = styled.div<{ opacity: number }>`
     `
   }}
 `
-const ScrollIcon = styled.div`
-  position: fixed;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 10px;
-  height: 104px;
-  color: #e1e1e1;
+const ScrollIcon = styled.div<{ visible: boolean }>`
+  ${({ visible }) => {
+    return css`
+      visibility: ${visible ? 'visible' : 'hidden'};
+      opacity: ${visible ? 1 : 0};
+      position: fixed;
+      bottom: 0;
+      left: 50%;
+      font-size: 10px;
+      height: 104px;
+      color: #e1e1e1;
+      transform: translateX(-50%);
+      transition: all 0.3s ease-in-out;
 
-  &::before {
-    display: block;
-    bottom: 0;
-    content: '';
-    position: absolute;
-    width: 1px;
-    height: 80px;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: #797979;
-  }
+      &::before {
+        display: block;
+        bottom: 0;
+        content: '';
+        position: absolute;
+        width: 1px;
+        height: 80px;
+        left: 50%;
+        transform: translateX(-50%);
+        background-color: #797979;
+      }
 
-  &::after {
-    display: block;
-    bottom: 56px;
-    content: '';
-    position: absolute;
-    width: 2px;
-    height: 0px;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: #ebebeb;
-    animation: ${scroll} 2s infinite;
-  }
+      &::after {
+        display: block;
+        bottom: 56px;
+        content: '';
+        position: absolute;
+        width: 2px;
+        height: 0px;
+        left: 50%;
+        transform: translateX(-50%);
+        background-color: #ebebeb;
+        animation: ${scroll} 2s infinite;
+      }
 
-  ${mediaQuery.mediumStyle(css`
-    height: 83px;
+      ${mediaQuery.mediumStyle(css`
+        height: 83px;
 
-    &::before {
-      height: 59px;
-    }
+        &::before {
+          height: 59px;
+        }
 
-    &::after {
-      bottom: 35px;
-    }
-  `)}
+        &::after {
+          bottom: 35px;
+        }
+      `)}
+    `
+  }}
 `

--- a/src/components/parts/EyeCatchEffects.tsx
+++ b/src/components/parts/EyeCatchEffects.tsx
@@ -1,0 +1,113 @@
+import React from 'react'
+import styled, { css, keyframes } from 'styled-components'
+
+import { mediaQuery } from '../../themes'
+import { useStoredScroll } from '../hooks/useStoredScroll'
+
+const MIN_OPACITY = 0.4
+
+const getCalculatedOpacity = (scrollY: number) => {
+  const halfInnerHeight = innerHeight / 2
+  const opacityRange = 1 - MIN_OPACITY
+  const scrollRange = opacityRange / halfInnerHeight
+  const y = -(scrollY - halfInnerHeight * 3)
+  const scroll = innerHeight - y
+  const amount = scroll * scrollRange
+
+  return 1 - amount
+}
+
+export const EyeCatchEffects = () => {
+  const { y } = useStoredScroll()
+  let opacity: number
+
+  if (y < innerHeight / 2) {
+    opacity = 1
+  } else if (y > innerHeight) {
+    opacity = MIN_OPACITY
+  } else {
+    opacity = getCalculatedOpacity(y)
+  }
+
+  return (
+    <>
+      <Underlay opacity={opacity} />
+      <ScrollIcon>SCROLL</ScrollIcon>
+    </>
+  )
+}
+
+const scroll = keyframes`
+  0% {
+    bottom: 80px;
+    height: 0px;
+  }
+
+  40% {
+    bottom: 0px;
+    height: 80px;
+  }
+
+  60% {
+    bottom: 0px;
+    height: 80px;
+  }
+
+  100% {
+    bottom: 0px;
+    height: 0px;
+  }
+`
+
+const Underlay = styled.div<{ opacity: number }>`
+  ${({ opacity }) => {
+    return css`
+      opacity: ${opacity};
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      background-image: url(/images/mv.png);
+      background-size: cover;
+      background-attachment: fixed;
+      background-position: top;
+
+      ${mediaQuery.smallStyle(css`
+        background-image: url(/images/mv_sp.png);
+      `)}
+    `
+  }}
+`
+const ScrollIcon = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 10px;
+  height: 104px;
+  color: #e1e1e1;
+  &::before {
+    display: block;
+    bottom: 0;
+    content: '';
+    position: absolute;
+    width: 1px;
+    height: 80px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #797979;
+  }
+  &::after {
+    display: block;
+    bottom: 56px;
+    content: '';
+    position: absolute;
+    width: 3px;
+    height: 0px;
+    animation: ${scroll} 1s infinite ease-in;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #ebebeb;
+  }
+`

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,1 +1,1 @@
-export { mediaQuery } from './size'
+export { mediaQuery, isMediumWindow } from './size'

--- a/src/themes/size.ts
+++ b/src/themes/size.ts
@@ -3,7 +3,9 @@ import { FlattenSimpleInterpolation } from 'styled-components'
 const mediumMaxWidth = 1199
 const smallMaxWidth = 739
 
+export const isMediumWindow = () => innerWidth < mediumMaxWidth
+
 export const mediaQuery = {
-  mediumStyle: (style: FlattenSimpleInterpolation) => `@media screen and (max-width: ${mediumMaxWidth}px) {${style}}`,
-  smallStyle: (style: FlattenSimpleInterpolation) => `@media screen and (max-width: ${smallMaxWidth}px) {${style}}`,
+  mediumStyle: (style: FlattenSimpleInterpolation) => `@media screen and (max-width: ${mediumMaxWidth}px) {${style.join('')}}`,
+  smallStyle: (style: FlattenSimpleInterpolation) => `@media screen and (max-width: ${smallMaxWidth}px) {${style.join('')}}`,
 }


### PR DESCRIPTION
## やりたいこと

- Underlay として置いているバックグラウンドイメージのフェードアウトをスクロールに合わせることでもっと気持ち良くしたい
- スクロールのアイコンのアニメーションをヌルッとさせたい

## やったこと

- バックグラウンドイメージにスクロールの量に合わせて計算した opacity を当てた
- スクロールアイコンのアニメーションを keyframes を調整した
- スクロールアイコンを特定の位置までスクロールしたらフェードアウトさせるようにした

## スクショ

ヌルッと感が伝わる gif にしようとするとファイルサイズがどうあってもデカすぎて貼れなかったのでローカルで動かして動作確認してください 🙏 