### PR TITLE
アコーディオンのトリガーをタイトル部分だけに絞る

### DIFF
--- a/src/components/parts/Accordion.tsx
+++ b/src/components/parts/Accordion.tsx
@@ -22,8 +22,10 @@ export const Accordion: FC<Props> = ({ title, children }) => {
   }
 
   return (
-    <AccordionWrapper onClick={toggleAccordion}>
-      <AccordionTitle className={isActive}>{title}</AccordionTitle>
+    <AccordionWrapper>
+      <AccordionTitle className={isActive} onClick={toggleAccordion} role="button">
+        {title}
+      </AccordionTitle>
       <AccordionContent ref={content} height={height}>
         {children}
       </AccordionContent>


### PR DESCRIPTION
## やりたいこと

現状だとアコーディオンの全てがクリックのトリガーとなっており、アコーディオンの中身をクリックした時も発動してアコーディオンが閉じてしまうのでちょっと不便。
テキスト選択したりとか不意にクリックしてしまった時に閉じちゃうとハッてなっちゃいそう…！
なのでタイトル部分のみをクリック領域にしたい。

## やったこと

- クリックの領域をタイトル部分に絞った
- タイトル部分を role="button" にした

## 注意点

本当は onClick の部分は button に変えるのが最善な気がするけど対応がちょっと大変そうだったので今回はそのままにして role だけの対応としました。