### PR TITLE
feat(welfare): welfareセクションのicon差し替え

### DIFF
--- a/src/components/parts/WelfareSection.tsx
+++ b/src/components/parts/WelfareSection.tsx
@@ -57,8 +57,7 @@ export const WelfareSection = () => (
 
     <LinkButton href="https://shanaiho.smarthr.co.jp/n/nf32ba99b0233" target="_blank" rel="noopener noreferrer">
       その他の福利厚生
-      {/* TODO: アイコンをいれる */}
-      <span>■</span>
+      <img src="/images/welfare/window_icon.svg" alt="icon" />
     </LinkButton>
   </Wrapper>
 )
@@ -149,12 +148,24 @@ const LinkButton = styled.a`
   font-weight: bold;
   letter-spacing: 0.85px;
 
+  & > img {
+    width: 24px;
+  }
+
   ${mediaQuery.mediumStyle(css`
     width: 100%;
+
+    & > img {
+      width: 20px;
+    }
   `)}
 
   ${mediaQuery.smallStyle(css`
     font-size: 16px;
     height: 70px;
+
+    & > img {
+      width: 18px;
+    }
   `)}
 `

--- a/static/images/welfare/window_icon.svg
+++ b/static/images/welfare/window_icon.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="レイヤー_1" focusable="false"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 512 512"
+	 style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#D3D3D3;}
+</style>
+<path class="st0" d="M464,0H144c-26.5,0-48,21.5-48,48v48H48c-26.5,0-48,21.5-48,48v320c0,26.5,21.5,48,48,48h320
+	c26.5,0,48-21.5,48-48v-48h48c26.5,0,48-21.5,48-48V48C512,21.5,490.5,0,464,0z M368,464H48V256h320V464z M464,368h-48V144
+	c0-26.5-21.5-48-48-48H144V48h320V368z"/>
+</svg>


### PR DESCRIPTION
## What

welfareセクションのiconを差し替えました。

## Screenshots

<details>
  <summary>PC</summary>

![image](https://user-images.githubusercontent.com/23610884/82000459-5f36b080-9693-11ea-9337-5e56b0000da7.png)
</details>

<details>
  <summary>Tablet</summary>

![image](https://user-images.githubusercontent.com/23610884/82000499-81303300-9693-11ea-94a6-eebfb6f526f3.png)

</details>

<details>
  <summary>SP</summary>

![image](https://user-images.githubusercontent.com/23610884/82000512-8db48b80-9693-11ea-82f3-cb599cd852dc.png)

</details>