### PR TITLE
Gatsby の静的ビルドで動かないコードの修正

### DIFF
--- a/src/components/hooks/useEventListener.ts
+++ b/src/components/hooks/useEventListener.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react'
 export const useEventListener = <T extends Event>(
   eventName: string,
   handler: (e: T) => void,
-  element: Element | Window = window,
+  element: Element | Window | null = typeof window !== 'undefined' ? window : null,
 ) => {
   const savedHandler = useRef<(e: T) => void>()
 
@@ -16,10 +16,14 @@ export const useEventListener = <T extends Event>(
       savedHandler.current && savedHandler.current(e)
     }
 
-    element.addEventListener(eventName, eventListener as any)
+    if (element) {
+      element.addEventListener(eventName, eventListener as any)
+    }
 
     return () => {
-      element.removeEventListener(eventName, eventListener as any)
+      if (element) {
+        element.removeEventListener(eventName, eventListener as any)
+      }
     }
   }, [eventName, element])
 }

--- a/src/components/hooks/useStoredScroll.ts
+++ b/src/components/hooks/useStoredScroll.ts
@@ -2,9 +2,9 @@ import { useCallback, useState } from 'react'
 import { useEventListener } from './useEventListener'
 
 export const useStoredScroll = () => {
-  const [y, setY] = useState(scrollY)
+  const [y, setY] = useState(typeof window !== 'undefined' ? window.scrollY : 0)
   const handleScroll = useCallback(() => {
-    setY(scrollY)
+    setY(typeof window !== 'undefined' ? window.scrollY : 0)
   }, [])
 
   useEventListener('scroll', handleScroll)

--- a/src/components/parts/EyeCatchEffects.tsx
+++ b/src/components/parts/EyeCatchEffects.tsx
@@ -6,24 +6,26 @@ import { useStoredScroll } from '../hooks/useStoredScroll'
 
 const MIN_OPACITY = 0.4
 
-const getCalculatedOpacity = (scrollY: number) => {
-  const halfInnerHeight = innerHeight / 2
+const getCalculatedOpacity = (scrollTop: number) => {
+  const height = typeof window !== 'undefined' ? window.innerHeight : 1
+  const halfInnerHeight = height / 2
   const opacityRange = 1 - MIN_OPACITY
   const scrollRange = opacityRange / halfInnerHeight
-  const y = -(scrollY - halfInnerHeight * 3)
-  const scroll = innerHeight - y
+  const y = -(scrollTop - halfInnerHeight * 3)
+  const scroll = height - y
   const amount = scroll * scrollRange
 
   return 1 - amount
 }
 
 export const EyeCatchEffects = () => {
+  const height = typeof window !== 'undefined' ? window.innerHeight : 1
   const { y } = useStoredScroll()
   let opacity: number
 
-  if (y < innerHeight / 2) {
+  if (y < height / 2) {
     opacity = 1
-  } else if (y > innerHeight) {
+  } else if (y > height) {
     opacity = MIN_OPACITY
   } else {
     opacity = getCalculatedOpacity(y)
@@ -32,7 +34,7 @@ export const EyeCatchEffects = () => {
   return (
     <>
       <Underlay opacity={opacity} />
-      <ScrollIcon visible={y < innerHeight / 2}>SCROLL</ScrollIcon>
+      <ScrollIcon visible={y < height / 2}>SCROLL</ScrollIcon>
     </>
   )
 }

--- a/src/themes/size.ts
+++ b/src/themes/size.ts
@@ -3,7 +3,7 @@ import { FlattenSimpleInterpolation } from 'styled-components'
 const mediumMaxWidth = 1199
 const smallMaxWidth = 739
 
-export const isMediumWindow = () => innerWidth < mediumMaxWidth
+export const isMediumWindow = () => (typeof window !== 'undefined' ? window.innerWidth < mediumMaxWidth : false)
 
 export const mediaQuery = {
   mediumStyle: (style: FlattenSimpleInterpolation) => `@media screen and (max-width: ${mediumMaxWidth}px) {${style.join('')}}`,


### PR DESCRIPTION
静的ビルド時は window オブジェクトが存在しないので、 window オブジェクトにぶら下がっているメソッドや値を呼ぶ際に window オブジェクトの存在確認をする。

参考: https://www.gatsbyjs.org/docs/debugging-html-builds/