### PR TITLE
Technology Stack の margin-top を調整

### DIFF
--- a/src/components/parts/AboutSection.tsx
+++ b/src/components/parts/AboutSection.tsx
@@ -43,7 +43,7 @@ export const AboutSection = () => (
 
 const Wrapper = styled.div`
   width: 100%;
-  padding: 20px 0;
+  padding: 20px 0 0;
 `
 const List = styled.ul`
   max-width: 1160px;

--- a/src/components/parts/TechnologyStackSection.tsx
+++ b/src/components/parts/TechnologyStackSection.tsx
@@ -56,9 +56,13 @@ export const TechnologyStackSection = () => (
 const Wrapper = styled.div`
   width: 100%;
   color: #d3d3d3;
+  margin-top: 230px;
+  ${mediaQuery.mediumStyle(css`
+    margin-top: 81px;
+  `)}
 
   ${mediaQuery.smallStyle(css`
-    padding: 40px 0;
+    margin-top: 38px;
   `)}
 `
 const Section = styled.section`


### PR DESCRIPTION
## before

pc
![image](https://user-images.githubusercontent.com/290611/82646475-a0106580-9c4f-11ea-9a66-4eee2666d4c0.png)

tablet
![image](https://user-images.githubusercontent.com/290611/82646514-adc5eb00-9c4f-11ea-9982-198de33a65d3.png)

mobile
![image](https://user-images.githubusercontent.com/290611/82646435-925ae000-9c4f-11ea-8f0d-05fde964b8fd.png)

## after

pc
![image](https://user-images.githubusercontent.com/290611/82646279-49a32700-9c4f-11ea-9274-7c2e27677c27.png)

tablet
![image](https://user-images.githubusercontent.com/290611/82646435-925ae000-9c4f-11ea-8f0d-05fde964b8fd.png)

mobile
![image](https://user-images.githubusercontent.com/290611/82646403-8707b480-9c4f-11ea-9946-e8b4832c044d.png)
