### PR TITLE
refactor: hover時にunderlineが消えるように修正

### DIFF
--- a/src/components/parts/MembersVoiceSection.tsx
+++ b/src/components/parts/MembersVoiceSection.tsx
@@ -327,5 +327,10 @@ const Member = styled.p`
   `)}
 `
 const Name = styled.span`
-  text-decoration: underline;
+  & > a {
+    text-decoration: underline;
+    &:hover {
+      text-decoration: none;
+    }
+  }
 `


### PR DESCRIPTION
## What

Members Voiceのエンジニアリンク、hover時にunderlineが消えるように修正しました。

##  Screenshots

<details>
  <summary>BEFORE</summary>
  
![May-22-2020 18-54-14](https://user-images.githubusercontent.com/23610884/82655809-bae9d680-9c5d-11ea-8c35-ac6d2f9976a2.gif)
</details>

<details>
  <summary>AFTER</summary>
  
![May-22-2020 18-58-55](https://user-images.githubusercontent.com/23610884/82656244-65fa9000-9c5e-11ea-9b22-a8fd6dc296dd.gif)

</details>
