### PR TITLE
:bug: dev と prd で起動時のローディングを出し分ける

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+NODE_ENV=development

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -2,13 +2,18 @@ import React from 'react'
 
 import { GatsbyWrapper } from './gatsby-wrapper'
 
-export const wrapPageElement = ({ element }) => <GatsbyWrapper>{element}</GatsbyWrapper>
+export const wrapPageElement = ({ element }) => {
+  if (process.env.NODE_ENV === 'development') return element
+  return <GatsbyWrapper>{element}</GatsbyWrapper>
+}
 
 export const onClientEntry = () => {
   window.onload = () => {
     const wrapper = document.getElementById('app-start-wrapper')
     const loading = document.getElementById('app-start-loading')
     const content = document.getElementById('app-start-content')
+
+    if (!wrapper || !loading || !content) return
 
     wrapper.style.overflow = 'visible'
     wrapper.style.position = 'static'

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -2,4 +2,7 @@ import React from 'react'
 
 import { GatsbyWrapper } from './gatsby-wrapper'
 
-export const wrapPageElement = ({ element }) => <GatsbyWrapper>{element}</GatsbyWrapper>
+export const wrapPageElement = ({ element }) => {
+  if (process.env.NODE_ENV === 'development') return element
+  return <GatsbyWrapper>{element}</GatsbyWrapper>
+}


### PR DESCRIPTION
初期起動時に development 環境の場合、 GatsbyWrapper の中身の存在を保証できないため、ローディング処理はプロダクションビルドの時のみに限定する。