### PR TITLE
リモートワークに関する説明をアップデートしました

### DIFF
--- a/src/components/parts/WelfareSection.tsx
+++ b/src/components/parts/WelfareSection.tsx
@@ -47,10 +47,10 @@ export const WelfareSection = () => (
         <ItemTitle>リモートワーク</ItemTitle>
         <Image src="/images/welfare/welfare6.jpg" alt="リモートワーク" />
         <ItemDescription>
-          リモートワークは事前申請のうえ週1回まで可能。好きな時間帯で4時間働けば良い半休制度と併用すると、日中の時間が有効に活用可能。
+          情勢を踏まえて、現在は全員フルリモート体制で勤務。今後については絶賛検討中で、積極的にリモートワークを取り入れる予定。
         </ItemDescription>
-        <Link href="https://shanaiho.smarthr.co.jp/n/nf32ba99b0233" target="_blank" rel="noopener noreferrer">
-          「シン・半休制度について」
+        <Link href="https://shanaiho.smarthr.co.jp/n/nb9e27c4f9fc0" target="_blank" rel="noopener noreferrer">
+          「感染症対策、リモートワークについて」
         </Link>
       </Item>
     </List>


### PR DESCRIPTION
## やりたいこと

福利厚生のリモートワークに関する説明が「before コロナ」なものだったので、「with コロナ」なものにアップデートしたい

## やったこと

こんな感じで文言とリンクを差し替えました。

**before**

<img src="https://user-images.githubusercontent.com/3301302/82993408-784c4380-a03b-11ea-8da1-ade698731a69.png" width="300px">

**after**

<img src="https://user-images.githubusercontent.com/3301302/82993434-81d5ab80-a03b-11ea-91dc-ae7a0b8d5688.png" width="300px">
