### PR TITLE
Technology Stack 部分のテキストを修正

### DIFF
--- a/src/components/parts/TechnologyStackSection.tsx
+++ b/src/components/parts/TechnologyStackSection.tsx
@@ -12,7 +12,7 @@ export const TechnologyStackSection = () => (
     <Section>
       <SectionHeadline>SmartHR</SectionHeadline>
       <Text>
-        開発に必要な技術は、現場の担当エンジニアがユーザとシステムにとって最適な技術を選定しています。SmartHR本体は、現在は以下の技術スタックの元に開発が進められています。
+        開発に必要な技術は、現場の担当エンジニアがユーザとシステムにとって最適な技術を選定しています。SmartHR本体は、現在は以下の技術スタックのもとに開発が進められています。
       </Text>
       <Supplements>
         <dt>プログラミング言語</dt>


### PR DESCRIPTION
## やったこと
- Technology Stack 部分のテキストの「元」を「もと」に変更
  - 恐らく漢字的には「下」が正しいと思うんですが、「以下の技術スタックの下に」だと「下」が連続で出現してやや読みづらい気がしたので平仮名にしました。
