### PR TITLE
やっぱりまだ IE でスタイルが崩れていたのを修正

### DIFF
--- a/src/components/pages/ie.tsx
+++ b/src/components/pages/ie.tsx
@@ -1,56 +1,60 @@
 import React from 'react'
 
 export const IePage = () => (
-  <div
-    style={{
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      height: '100vh',
-      backgroundColor: '#fff',
-      color: '#646464',
-      font: 'normal 64px/63px Helvetica, Arial, sans-serif',
-      textAlign: 'center',
-    }}
-  >
+  <div>
     <div>
-      <p style={{ marginBottom: '20px' }}>
-        あなたと Chrome,
-        <br />
-        今すぐダウンロー
-        <br />ド
-      </p>
-
-      <a
-        href="https://www.google.com/intl/ja_jp/chrome/"
-        title="無料Chromeのダウンロード"
+      <div
         style={{
-          display: 'block',
-          width: '244px',
-          margin: '0 auto',
-          borderRadius: '6px',
-          border: '1px solid #e99c98',
-          background: 'linear-gradient(#ecadaa, #d23019)',
-          color: '#fff',
-          fontWeight: 'bold',
-          fontSize: '14px',
-          lineHeight: '47px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100vh',
+          backgroundColor: '#fff',
+          color: '#646464',
+          font: 'normal 64px/63px Helvetica, Arial, sans-serif',
+          textAlign: 'center',
         }}
       >
-        無料Chromeのダウンロード
-      </a>
+        <div>
+          <p style={{ marginBottom: '20px' }}>
+            あなたと Chrome,
+            <br />
+            今すぐダウンロー
+            <br />ド
+          </p>
 
-      <p
-        style={{
-          marginTop: '20px',
-          fontSize: '14px',
-          lineHeight: '1.4',
-        }}
-      >
-        ※このページは SmartHR のエンジニア採用サイトです。
-        <br />
-        Internet Explorer には対応していません。
-      </p>
+          <a
+            href="https://www.google.com/intl/ja_jp/chrome/"
+            title="無料Chromeのダウンロード"
+            style={{
+              display: 'block',
+              width: '244px',
+              margin: '0 auto',
+              borderRadius: '6px',
+              border: '1px solid #e99c98',
+              background: 'linear-gradient(#ecadaa, #d23019)',
+              color: '#fff',
+              fontWeight: 'bold',
+              fontSize: '14px',
+              lineHeight: '47px',
+            }}
+          >
+            無料Chromeのダウンロード
+          </a>
+
+          <p
+            style={{
+              marginTop: '20px',
+              fontSize: '14px',
+              lineHeight: '1.4',
+            }}
+          >
+            ※このページは SmartHR のエンジニア採用サイトです。
+            <br />
+            Internet Explorer には対応していません。
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11153463/83096046-adaa6d00-a0df-11ea-93c8-39dc82b35514.png)

style 属性でスタイルを当てるようにしたが、 Gatsby の仕様なのかルートにあたるコンポーネントが上書きされてしまいスタイルが当たらなかったので、根本対応ではないが一旦の策として空の div でネストさせてみる