### PR TITLE
Remove 「感染症対策、リモートワークについて」 link

### DIFF
--- a/src/components/parts/BenefitsSection.tsx
+++ b/src/components/parts/BenefitsSection.tsx
@@ -50,9 +50,6 @@ export const BenefitsSection = () => (
         <ItemDescription>
           情勢を踏まえて、現在は全員フルリモート体制で勤務。今後については絶賛検討中で、積極的にリモートワークを取り入れる予定。
         </ItemDescription>
-        <Link href="https://shanaiho.smarthr.co.jp/n/nb9e27c4f9fc0" target="_blank" rel="noopener noreferrer">
-          「感染症対策、リモートワークについて」
-        </Link>
       </Item>
     </List>
 


### PR DESCRIPTION
「感染症対策、リモートワークについて」の記事は古くなっているので削除しました。

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/7158259/99632902-6050fc00-2a81-11eb-9475-94ab52bd59b9.png) | ![image](https://user-images.githubusercontent.com/7158259/99632876-4f07ef80-2a81-11eb-9729-cdc87cb26220.png) |
