### PR TITLE
fix: 「その他の福利厚生」のリンク先を修正

### DIFF
--- a/src/components/parts/BenefitsSection.tsx
+++ b/src/components/parts/BenefitsSection.tsx
@@ -53,7 +53,7 @@ export const BenefitsSection = () => (
       </Item>
     </List>
 
-    <LinkButton href="https://speakerdeck.com/miyasho88/we-are-hiring?slide=38" target="_blank" rel="noopener noreferrer">
+    <LinkButton href="https://speakerdeck.com/miyasho88/we-are-hiring?slide=42" target="_blank" rel="noopener noreferrer">
       その他の福利厚生
       <img src="/images/benefits/window_icon.svg" alt="外部サイトへのリンク" />
     </LinkButton>


### PR DESCRIPTION
組織外から失礼します。
「SmartHR会社紹介資料」にスライドが追加された影響で、「その他の福利厚生」リンクの遷移先が「参考: プラットフォーム化構想」になっていたため修正いたしました。