### PR TITLE
GitHub へのリンクを追加

### DIFF
--- a/src/components/parts/EyeCatch.tsx
+++ b/src/components/parts/EyeCatch.tsx
@@ -11,7 +11,13 @@ export const EyeCatch = () => (
         <SiteTitle>Engineer Recruiting</SiteTitle>
       </Logo>
 
-      <PcEntryButton href="#entry">ENTRY</PcEntryButton>
+      <PcButtonArea>
+        <GitHubLink href="https://github.com/kufu/hello-world" target="_blank" rel="noopener noreferrer">
+          GitHub
+        </GitHubLink>
+
+        <PcEntryButton href="#entry">ENTRY</PcEntryButton>
+      </PcButtonArea>
     </Header>
 
     <PageTitle>
@@ -76,7 +82,26 @@ const SiteTitle = styled.p`
     font-size: 12px;
   `)}
 `
+const PcButtonArea = styled.div`
+  display: flex;
+  align-items: center;
+
+  ${mediaQuery.smallStyle(css`
+    display: none;
+  `)}
+`
+const GitHubLink = styled.a`
+  margin-right: 18px;
+  color: #fff;
+  font-size: 16px;
+  text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
+  }
+`
 const PcEntryButton = styled.a`
+  display: block;
   width: 130px;
   padding: 12px 0;
   border-radius: 35px;
@@ -90,10 +115,6 @@ const PcEntryButton = styled.a`
   &:hover {
     opacity: 0.7;
   }
-
-  ${mediaQuery.smallStyle(css`
-    display: none;
-  `)}
 `
 const PageTitle = styled.h1`
   position: relative;


### PR DESCRIPTION
このページから GitHub に飛べた方が面白そうなので追加しました。

![image](https://user-images.githubusercontent.com/11153463/109904308-60979f00-7ce0-11eb-885f-4cd4a4f0da75.png)

PC 表示の時だけ表示されます。
配置としては見つけて欲しいので ENTRY ボタンの隣に置いていますが、 ENTRY ボタンよりは重要度が低いので見た目はただのテキストリンクにしています。

スマホ表示の時のリンクの置き場所に困ったという問題がまずあり、そしてスマホで見た時に GitHub 飛べてもあんまり嬉しくなさそうとかそもそも採用サイト見るエンジニアは PC で見そうだしいっか、と思いスマホでは表示されません。

割と雰囲気でやったのでだめそうなら reject してください 🙏 