### PR TITLE
KV の SCROLL アイコンがメッセージの冒頭に干渉しないよう、非表示の位置を調整

### DIFF
--- a/src/components/parts/EyeCatchEffects.tsx
+++ b/src/components/parts/EyeCatchEffects.tsx
@@ -10,6 +10,7 @@ export const EyeCatchEffects: FC = () => {
   const height = typeof window !== 'undefined' ? window.innerHeight : 1
   const { y } = useStoredScroll()
   const visible = y < height / 2
+  const visibleScrollIcon = y < height / 5
   const supportsWebp = useWebp()
   const { baseCanvasRef, targetCanvasRef } = useContext(ImageEffectContext)
 
@@ -19,7 +20,7 @@ export const EyeCatchEffects: FC = () => {
       <BaseCanvas ref={baseCanvasRef} />
       <TargetCanvas ref={targetCanvasRef} />
       <UnderlayCover visible={visible} />
-      <ScrollIcon visible={visible}>SCROLL</ScrollIcon>
+      <ScrollIcon visible={visibleScrollIcon}>SCROLL</ScrollIcon>
     </>
   )
 }


### PR DESCRIPTION
ファーストビューで見えている SCROLL アイコンが、メッセージテキストの冒頭に被って見える場合があったため、 SCROLL アイコンを非表示にするスクロール位置を調整してみました。
なお、オーバーレイが表示されるタイミングはそのままとしています。

### Before

![スクリーンショット 2021-05-27 22 53 02](https://user-images.githubusercontent.com/52390331/119840096-a2cb2800-bf3f-11eb-8fae-337eb4d86389.jpg)

### After

![スクリーンショット 2021-05-27 22 52 50](https://user-images.githubusercontent.com/52390331/119840130-a9f23600-bf3f-11eb-9c39-2fe958e12ae3.jpg)


## コメント
有益なコードの公開、ありがとうございます！
サイトを拝見していて少し気になったので、改善案をプルリクさせていただきました。
ご一考いただけますと幸いです。