### PR TITLE
アコーディオン開閉時の矢印のアニメーションを微調整

### DIFF
--- a/src/components/parts/Accordion.tsx
+++ b/src/components/parts/Accordion.tsx
@@ -60,6 +60,7 @@ const AccordionTitle = styled.dt`
     top: 50%;
     right: 30px;
     margin-top: -3px;
+    transition: transform 0.4s ease;
   }
 
   &.active {

--- a/src/components/parts/EyeCatchEffects.tsx
+++ b/src/components/parts/EyeCatchEffects.tsx
@@ -10,6 +10,7 @@ export const EyeCatchEffects: FC = () => {
   const height = typeof window !== 'undefined' ? window.innerHeight : 1
   const { y } = useStoredScroll()
   const visible = y < height / 2
+  const visibleScrollIcon = y < height / 5
   const supportsWebp = useWebp()
   const { baseCanvasRef, targetCanvasRef } = useContext(ImageEffectContext)
 
@@ -19,7 +20,7 @@ export const EyeCatchEffects: FC = () => {
       <BaseCanvas ref={baseCanvasRef} />
       <TargetCanvas ref={targetCanvasRef} />
       <UnderlayCover visible={visible} />
-      <ScrollIcon visible={visible}>SCROLL</ScrollIcon>
+      <ScrollIcon visible={visibleScrollIcon}>SCROLL</ScrollIcon>
     </>
   )
 }

--- a/src/components/parts/EyeCatchEffects.tsx
+++ b/src/components/parts/EyeCatchEffects.tsx
@@ -10,7 +10,6 @@ export const EyeCatchEffects: FC = () => {
   const height = typeof window !== 'undefined' ? window.innerHeight : 1
   const { y } = useStoredScroll()
   const visible = y < height / 2
-  const visibleScrollIcon = y < height / 5
   const supportsWebp = useWebp()
   const { baseCanvasRef, targetCanvasRef } = useContext(ImageEffectContext)
 
@@ -20,7 +19,7 @@ export const EyeCatchEffects: FC = () => {
       <BaseCanvas ref={baseCanvasRef} />
       <TargetCanvas ref={targetCanvasRef} />
       <UnderlayCover visible={visible} />
-      <ScrollIcon visible={visibleScrollIcon}>SCROLL</ScrollIcon>
+      <ScrollIcon visible={visible}>SCROLL</ScrollIcon>
     </>
   )
 }


### PR DESCRIPTION
本サイトは、見たところほぼすべてのインタラクションに transition が設定されていますが、 Members Voice セクションのアコーディオンの開閉時において、矢印のアニメーションの transition が設定されておらずパッと切り替わることに違和感を覚えましたので、 transition を設定してみました。

上記の対応を取ることで、アコーディオン開閉自体の動きと同調し、自然な動きになるかなと思います。

![43535aecf4291ae5878db234506d2e7b](https://user-images.githubusercontent.com/52390331/119843820-dce9f900-bf42-11eb-8ae6-2d32b9e8f63b.gif)

## コメント
有益なコードの公開、ありがとうございます！
サイトを拝見していて少し気になったので、改善案をプルリクさせていただきました。
ご一考いただけますと幸いです。