### PR TITLE
feat: add margin to EntrySection item

### DIFF
--- a/src/components/parts/EntrySection.tsx
+++ b/src/components/parts/EntrySection.tsx
@@ -137,6 +137,8 @@ const Item = styled.a`
 
   > span {
     font-size: 14px;
+    display: inline-block;
+    margin-top: 6px;
   }
 
   ${mediaQuery.largeStyle(css`


### PR DESCRIPTION
# What
マージンを足させていただきました

# Why
spanに余白がないので文字がかぶって見えていました
<img width="1150" alt="スクリーンショット 2021-07-08 22 29 14" src="https://user-images.githubusercontent.com/28397593/124930928-b12b5a00-e03c-11eb-9666-50a2a1754938.png">

余白を設け、かぶって見えない程度に調整しました
<img width="824" alt="スクリーンショット 2021-07-08 22 32 51" src="https://user-images.githubusercontent.com/28397593/124931122-df109e80-e03c-11eb-9cde-f220e4c4d08f.png">
