### PR TITLE
募集職種名が変更になったので合わせる

### DIFF
--- a/src/components/parts/EntrySection.tsx
+++ b/src/components/parts/EntrySection.tsx
@@ -30,16 +30,14 @@ export const EntrySection = () => (
         </li>
         <li>
           <Item href="https://open.talentio.com/1/c/smarthr/requisitions/detail/12856" target="_blank" rel="noopener noreferrer">
-            テストエンジニア
+            SET
             <BrSp />
             <span>（Software Engineer in Test）</span>
           </Item>
         </li>
         <li>
           <Item href="https://open.talentio.com/1/c/smarthr/requisitions/detail/12855" target="_blank" rel="noopener noreferrer">
-            QA
-            <BrSp />
-            <span>（品質保証）</span>
+            QAエンジニア
           </Item>
         </li>
         <li>


### PR DESCRIPTION
QA及びテストエンジニアの募集職種名称が以下のように変更になりました。
エンジニア採用サイトでも同じ名称にしたいので変更します。

**変更内容**
QA(品質保証) → QAエンジニア
テストエンジニア(Software Engineer in Test) → SET(Software Engineer in Test)

![スクリーンショット 2021-07-14 15 36 20](https://user-images.githubusercontent.com/1168982/125575410-805fc1d2-4695-46b9-85f8-78b9d6dcef05.png)
