### PR TITLE
PNG, WebP の画像を両方取得している問題を修正

### DIFF
--- a/src/components/commandPalette/commands/ImageEffect.tsx
+++ b/src/components/commandPalette/commands/ImageEffect.tsx
@@ -88,7 +88,7 @@ export const useImageEffect = (fragmentShaderSource: string) => {
     window.addEventListener('resize', drawImageOnCanvas)
     if (!imageDom.current.src) {
       imageDom.current.addEventListener('load', drawImageOnCanvas, { once: true })
-      imageDom.current.src = supportsWebp ? '/images/mv.webp' : '/images/mv.png'
+      imageDom.current.src = supportsWebp === null ? `` : supportsWebp ? '/images/mv.webp' : '/images/mv.png'
     }
 
     const context = canvasContext.current

--- a/src/components/hooks/useWebp.ts
+++ b/src/components/hooks/useWebp.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 export const useWebp = () => {
-  const [enableWebp, setEnableWebp] = useState(false)
+  const [enableWebp, setEnableWebp] = useState<boolean | null>(null)
 
   if (typeof Image !== 'undefined') {
     const img = new Image()

--- a/src/components/parts/EyeCatchEffects.tsx
+++ b/src/components/parts/EyeCatchEffects.tsx
@@ -43,7 +43,7 @@ const scroll = keyframes`
   }
 `
 
-const Underlay = styled.div<{ supportsWebp: boolean }>`
+const Underlay = styled.div<{ supportsWebp: boolean | null }>`
   ${({ supportsWebp }) => {
     return css`
       position: fixed;
@@ -52,12 +52,20 @@ const Underlay = styled.div<{ supportsWebp: boolean }>`
       width: 100%;
       height: 100vh;
 
-      ${supportsWebp ? `background-image: url(/images/mv.webp);` : `background-image: url(/images/mv.png);`}
+      ${supportsWebp === null
+        ? ``
+        : supportsWebp
+        ? `background-image: url(/images/mv.webp);`
+        : `background-image: url(/images/mv.png);`}
       background-size: cover;
       background-position: top;
 
       ${mediaQuery.smallStyle(css`
-        ${supportsWebp ? `background-image: url(/images/mv_sp.webp);` : `background-image: url(/images/mv_sp.png);`}
+        ${supportsWebp === null
+          ? ``
+          : supportsWebp
+          ? `background-image: url(/images/mv_sp.webp);`
+          : `background-image: url(/images/mv_sp.png);`}
       `)}
     `
   }}


### PR DESCRIPTION
WebP の判定が非同期で呼ばれる関係で、PNGとWebPの両方がダウンロードされています。

<img width="954" alt="image" src="https://user-images.githubusercontent.com/9423/125609921-c57ce177-1c70-4682-87b9-14fac6345241.png">


フロー

1. useWebp を呼ぶ
2. onload が動作する前に false を返す
3. png 画像のダウンロードを始める
4. onload が動作し、useWebp が true になる
5. webp 画像のダウンロードを始める

mv.png はサイズが大きいのでできればダウンロードをしたくありません。useWebp の判定が行われるまでは画像に空文字列を指定しておき、ダウンロードが走らないようにしました。