### PR TITLE
ブラウザ・CDNでコンテンツをキャッシュさせるヘッダーを設定

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,24 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    cache-control = "public, max-age=3600"
+
+[[headers]]
+  for = "/app-*.js"
+  [headers.values]
+    cache-control = "public, max-age=31536000"
+
+[[headers]]
+  for = "/commons-*.js"
+  [headers.values]
+    cache-control = "public, max-age=31536000"
+
+[[headers]]
+  for = "/component-*.js"
+  [headers.values]
+    cache-control = "public, max-age=31536000"
+
+[[headers]]
+  for = "/webpack-runtime-*.js"
+  [headers.values]
+    cache-control = "public, max-age=31536000"


### PR DESCRIPTION
Netlify はレスポンスヘッダーに `cache-control: public, max-age=0, must-revalidate` をつけるので、結果として Cloudflare のキャッシュが有効に動作せず、直接 netlify にアクセスするよりも遅い状態になっています。

hello-world.smarthr.co.jp

<img width="1509" alt="cloudflare" src="https://user-images.githubusercontent.com/9423/125707222-13cdfad1-9188-4b02-96bc-be522d04d7ad.png">

netlify直接アクセス

<img width="1508" alt="netlify" src="https://user-images.githubusercontent.com/9423/125707242-6e1f05eb-db2c-4b22-bc49-a61a05aa6da9.png">

経路・ブラウザでのキャッシュを有効化するために、netlify のレスポンスヘッダー設定を変更しました。

以下のルールにしていますが、キャッシュ期間についてはコメントがあればいただきたいです:

- デフォルトで1時間キャッシュ
- ファイル名にダイジェストを含むファイルは内容が変わったときにパスが変わるので、長期間（1年間）キャッシュ