### PR TITLE
隠しコマンドのエフェクトが表示されないバグを修正

### DIFF
--- a/src/components/commandPalette/commands/ImageEffect.tsx
+++ b/src/components/commandPalette/commands/ImageEffect.tsx
@@ -36,6 +36,7 @@ export const useImageEffect = (fragmentShaderSource: string) => {
 
   const drawImageOnCanvas = useCallback(() => {
     if (!canvas || !canvasContext.current) return
+
     const { naturalWidth, naturalHeight } = imageDom.current
     const { innerHeight } = window
     const innerWidth = document.body.clientWidth
@@ -86,7 +87,7 @@ export const useImageEffect = (fragmentShaderSource: string) => {
 
   useEffect(() => {
     window.addEventListener('resize', drawImageOnCanvas)
-    if (!imageDom.current.src) {
+    if (!imageDom.current.src && supportsWebp) {
       imageDom.current.addEventListener('load', drawImageOnCanvas, { once: true })
       imageDom.current.src = supportsWebp === null ? `` : supportsWebp ? '/images/mv.webp' : '/images/mv.png'
     }


### PR DESCRIPTION
## やりたいこと

隠しコマンドで glitch と starry night を選択したときにエフェクトが表示されないバグを直したい

## やったこと

webp が使えるかどうかのフラグが画像の読み込み部分とうまいこと噛み合っていなかったので条件分岐を変えた。
いつからここが動かなくなっていたのかはわからない…

## 確認手順

Cmd + Shift + P でコマンドパレットが出るので、その後「glitch」と「starry night」を選択してエフェクトが発生するかを確認する