### PR TITLE
Avoid obsolete property on `KeyboardEvent`

### DIFF
--- a/src/components/commandPalette/CommandPaletteUI.tsx
+++ b/src/components/commandPalette/CommandPaletteUI.tsx
@@ -19,8 +19,7 @@ export const CommandPaletteUI: FC<Props> = ({ commandNames, searchText, classNam
 
   const handleKeyPress = useCallback(
     (e: KeyboardEvent) => {
-      // up
-      if (e.keyCode === 38) {
+      if (e.key === 'ArrowUp') {
         e.preventDefault()
 
         if (currentIndex === 0) {
@@ -30,8 +29,7 @@ export const CommandPaletteUI: FC<Props> = ({ commandNames, searchText, classNam
         }
       }
 
-      // down
-      if (e.keyCode === 40) {
+      if (e.key === 'ArrowDown') {
         e.preventDefault()
 
         if (currentIndex === commandNames.length - 1) {


### PR DESCRIPTION
Use `KeyboardEvent.key` instead of `KeyboardEvent.keyCode`.
- https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key

See also:
- https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
- https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#obsolete_properties

> Warning: This attribute is deprecated; you should use KeyboardEvent.key instead, if available.

There is a similar property `KeyboardEvent.code`.
It represents a physical key on the keyboard and is not used here.
- https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code

> The KeyboardEvent.code property represents a physical key on the keyboard (as opposed to the character generated by pressing the key). In other words, this property returns a value that isn't altered by keyboard layout or the state of the modifier keys.

> To determine what character corresponds with the key event, use the KeyboardEvent.key property instead.

Resolves https://github.com/kufu/hello-world/issues/101