### PR TITLE
福利厚生のページが40から38に変わってるので追従

### DIFF
--- a/src/components/parts/BenefitsSection.tsx
+++ b/src/components/parts/BenefitsSection.tsx
@@ -58,7 +58,7 @@ export const BenefitsSection = () => (
       </Item>
     </List>
 
-    <LinkButton href="https://speakerdeck.com/miyasho88/we-are-hiring?slide=40" target="_blank" rel="noopener noreferrer">
+    <LinkButton href="https://speakerdeck.com/miyasho88/we-are-hiring?slide=38" target="_blank" rel="noopener noreferrer">
       その他の福利厚生
       <img src="/images/benefits/window_icon.svg" alt="外部サイトへのリンク" />
     </LinkButton>


### PR DESCRIPTION
40だとここ
https://speakerdeck.com/miyasho88/we-are-hiring?slide=40

今は38が多分正しいはず！
https://speakerdeck.com/miyasho88/we-are-hiring?slide=38