### PR TITLE
Win環境ではコマンドパレットが開けないようなので修正

### DIFF
--- a/src/components/commandPalette/CommandPalette.tsx
+++ b/src/components/commandPalette/CommandPalette.tsx
@@ -67,7 +67,7 @@ export const CommandPaletteProvider: FC<{
       }}
     >
       <Hotkeys
-        keyName="command+shift+p"
+        keyName="command+shift+p, ctrl+shift+p"
         onKeyDown={(_, e) => {
           e.preventDefault()
           setCommand(null)


### PR DESCRIPTION
## 概要
サイトとソースコードを閲覧していたところコマンドパレットの機能があるのを見つけて使おうとしましたが  
Win端末ではcommandキーが存在せず、コマンドパレットが開けなかったため修正してみました。

## 備考
端末を判定して呼び出すキーを変更する処理にしようとも思いましたが[`Navigator.platform`](https://developer.mozilla.org/ja/docs/Web/API/Navigator/platform)が既に非推奨になっていることとUA判定自体が推奨されない操作なので`Ctrl+Shift+P`でも呼び出せるように変更してみました。

もしよろしければご確認お願いします🙇

| OS | Browser |
|---|---|
| Windows 10 Version 21H2 (Build 19044.1826) |  Google Chrome 103.0.5060.114 |