### PR TITLE
福利厚生のページが変わっていたので追従

### DIFF
--- a/src/components/parts/BenefitsSection.tsx
+++ b/src/components/parts/BenefitsSection.tsx
@@ -58,7 +58,7 @@ export const BenefitsSection = () => (
       </Item>
     </List>
 
-    <LinkButton href="https://speakerdeck.com/miyasho88/we-are-hiring?slide=38" target="_blank" rel="noopener noreferrer">
+    <LinkButton href="https://speakerdeck.com/miyasho88/we-are-hiring?slide=35" target="_blank" rel="noopener noreferrer">
       その他の福利厚生
       <img src="/images/benefits/window_icon.svg" alt="外部サイトへのリンク" />
     </LinkButton>


### PR DESCRIPTION
https://speakerdeck.com/miyasho88/we-are-hiring?slide=38

から

https://speakerdeck.com/miyasho88/we-are-hiring?slide=35

に変わっていました。
