### PR TITLE
求人情報をアップデート

### DIFF
--- a/src/components/parts/EntrySection.tsx
+++ b/src/components/parts/EntrySection.tsx
@@ -33,11 +33,13 @@ export const EntrySection = () => (
             プラットフォーム開発エンジニア（バックエンド）
           </Item>
         </li>
+        {/* MEMO: 募集停止中
         <li>
           <Item href="https://open.talentio.com/r/1/c/smarthr/pages/75924" target="_blank" rel="noopener noreferrer">
             プラットフォーム開発エンジニア（フロントエンド）
           </Item>
         </li>
+        */}
         <li>
           <Item href="https://open.talentio.com/r/1/c/smarthr/pages/45053" target="_blank" rel="noopener noreferrer">
             QAエンジニア

--- a/src/components/parts/EntrySection.tsx
+++ b/src/components/parts/EntrySection.tsx
@@ -19,7 +19,7 @@ export const EntrySection = () => (
       </Message>
       <List>
         <li>
-          <Item href="https://open.talentio.com/r/1/c/smarthr/pages/45049" target="_blank" rel="noopener noreferrer">
+          <Item href="https://open.talentio.com/r/1/c/smarthr/pages/82214" target="_blank" rel="noopener noreferrer">
             ウェブアプリケーションエンジニア（バックエンド）
           </Item>
         </li>


### PR DESCRIPTION
## やりたいこと

ウェブアプリケーションエンジニア（バックエンド）とプラットフォーム開発エンジニア（フロントエンド）のリンクを開くと、「入力されたURLページが存在しません。」と表示されるので、正しい情報に修正したい。

## やったこと

- ウェブアプリケーションエンジニア（バックエンド）のURLを[ウェブアプリケーションエンジニア（オープンポジション バックエンド）](https://open.talentio.com/r/1/c/smarthr/pages/82214)に変更
- プラットフォーム開発エンジニア（フロントエンド）を非表示にする
  - CLOSEされたので

| Before | After |
| --- | --- |
| ![image](https://github.com/kufu/hello-world/assets/45530245/7a656859-fd07-4872-b645-44b95b9a4554) | ![image](https://github.com/kufu/hello-world/assets/45530245/39b7b95c-2aa9-4b8e-971a-9921336cafda) |

## やらなかったこと

- ウェブアプリケーションエンジニア（バックエンド）をウェブアプリケーションエンジニア（オープンポジション バックエンド）という名称に変更すること
  - 改行しないと表示できなさそうだったので、とりあえずリンクを復活させることを最優先として対応しませんでした
- その他の追加された求人を追加すること
