### PR TITLE
求人情報の追加とスタイル調整

### DIFF
--- a/src/components/parts/EntrySection.tsx
+++ b/src/components/parts/EntrySection.tsx
@@ -20,12 +20,16 @@ export const EntrySection = () => (
       <List>
         <li>
           <Item href="https://open.talentio.com/r/1/c/smarthr/pages/82214" target="_blank" rel="noopener noreferrer">
-            ウェブアプリケーションエンジニア（バックエンド）
+            ウェブアプリケーションエンジニア
+            <BrPc />
+            （オープンポジション バックエンド）
           </Item>
         </li>
         <li>
           <Item href="https://open.talentio.com/r/1/c/smarthr/pages/82223" target="_blank" rel="noopener noreferrer">
-            ウェブアプリケーションエンジニア（フロントエンド）
+            ウェブアプリケーションエンジニア
+            <BrPc />
+            （オープンポジション フロントエンド）
           </Item>
         </li>
         <li>
@@ -129,6 +133,8 @@ const Item = styled.a`
   font-weight: bold;
   font-size: 18px;
   letter-spacing: 0.69px;
+  text-align: center;
+  line-height: 1.3;
 
   &::after {
     position: absolute;
@@ -170,10 +176,10 @@ const BrPc = styled.br`
     display: none;
   `)}
 `
-const BrSp = styled.br`
-  display: none;
+// const BrSp = styled.br`
+//   display: none;
 
-  ${mediaQuery.smallStyle(css`
-    display: block;
-  `)}
-`
+//   ${mediaQuery.smallStyle(css`
+//     display: block;
+//   `)}
+// `

--- a/src/components/parts/EntrySection.tsx
+++ b/src/components/parts/EntrySection.tsx
@@ -33,6 +33,34 @@ export const EntrySection = () => (
           </Item>
         </li>
         <li>
+          <Item href="https://open.talentio.com/r/1/c/smarthr/pages/82193" target="_blank" rel="noopener noreferrer">
+            ウェブアプリケーションエンジニア
+            <BrPc />
+            （労務領域 バックエンド）
+          </Item>
+        </li>
+        <li>
+          <Item href="https://open.talentio.com/r/1/c/smarthr/pages/82217" target="_blank" rel="noopener noreferrer">
+            ウェブアプリケーションエンジニア
+            <BrPc />
+            （労務領域 フロントエンド）
+          </Item>
+        </li>
+        <li>
+          <Item href="https://open.talentio.com/r/1/c/smarthr/pages/82188" target="_blank" rel="noopener noreferrer">
+            ウェブアプリケーションエンジニア
+            <BrPc />
+            （タレントマネジメント領域 バックエンド）
+          </Item>
+        </li>
+        <li>
+          <Item href="https://open.talentio.com/r/1/c/smarthr/pages/82220" target="_blank" rel="noopener noreferrer">
+            ウェブアプリケーションエンジニア
+            <BrPc />
+            （タレントマネジメント領域 フロントエンド）
+          </Item>
+        </li>
+        <li>
           <Item href="https://open.talentio.com/r/1/c/smarthr/pages/75921" target="_blank" rel="noopener noreferrer">
             プラットフォーム開発エンジニア（バックエンド）
           </Item>


### PR DESCRIPTION
## やりたいこと

求人情報を追加したい

## やったこと

以下の情報を追加。

- [ウェブアプリケーションエンジニア（労務領域 バックエンド）](https://open.talentio.com/r/1/c/smarthr/pages/82193)
- [ウェブアプリケーションエンジニア（労務領域 フロントエンド）](https://open.talentio.com/r/1/c/smarthr/pages/82217)
- [ウェブアプリケーションエンジニア（タレントマネジメント領域 バックエンド）](https://open.talentio.com/r/1/c/smarthr/pages/82188)
- [ウェブアプリケーションエンジニア（タレントマネジメント領域 フロントエンド）](https://open.talentio.com/r/1/c/smarthr/pages/82220)

また、既存のウェブアプリケーションエンジニアのバックエンドとフロントエンドの名称も変更しています。

また、名称が長くボタンのスタイルが崩れるので改行を入れるのと行間の調整をしました

## キャプチャ

| Before | After |
|:--|:--|
| <img width="622" alt="image" src="https://github.com/kufu/hello-world/assets/11153463/b17c67dd-159c-46a9-be5f-2b9d60b96fea"> | <img width="627" alt="image" src="https://github.com/kufu/hello-world/assets/11153463/910e72f0-12b0-4c5c-aa6b-30da1d4fb61f"> |

ボタンが多すぎてぱっと見わかりづらくて本当にこれで良いのか感はある…