### PR TITLE
会社紹介資料セクションを追加

### DIFF
--- a/src/components/sections/Document.astro
+++ b/src/components/sections/Document.astro
@@ -6,7 +6,9 @@ import TextLink from '../shared/TextLink.astro'
 
 <SectionWrapper heading="会社紹介資料">
   <Stack>
-    <p>SmartHRの全職種向け採用資料です。エンジニア採用サイトには、この資料では触れられていないエンジニア向けの情報を記載しています。</p>
+    <p>
+      SmartHRの全職種向け採用資料です。エンジニア採用サイトには、この資料では触れられていないエンジニア向けの情報を記載しています。
+    </p>
     <p>
       <TextLink href="https://speakerdeck.com/miyasho88/we-are-hiring">会社紹介資料を見る</TextLink>
     </p>

--- a/src/components/sections/Document.astro
+++ b/src/components/sections/Document.astro
@@ -1,10 +1,14 @@
 ---
 import SectionWrapper from '../shared/SectionWrapper.astro'
 import Stack from '../shared/Stack.astro'
+import TextLink from '../shared/TextLink.astro'
 ---
 
 <SectionWrapper heading="会社紹介資料">
   <Stack>
-    <p>テスト</p>
+    <p>SmartHR の全職種向け採用資料です。エンジニア採用サイトには、この資料では触れられていないエンジニア向けの情報を記載しています。</p>
+    <p>
+      <TextLink href="https://speakerdeck.com/miyasho88/we-are-hiring">会社紹介資料を見る</TextLink>
+    </p>
   </Stack>
 </SectionWrapper>

--- a/src/components/sections/Document.astro
+++ b/src/components/sections/Document.astro
@@ -6,7 +6,7 @@ import TextLink from '../shared/TextLink.astro'
 
 <SectionWrapper heading="会社紹介資料">
   <Stack>
-    <p>SmartHR の全職種向け採用資料です。エンジニア採用サイトには、この資料では触れられていないエンジニア向けの情報を記載しています。</p>
+    <p>SmartHRの全職種向け採用資料です。エンジニア採用サイトには、この資料では触れられていないエンジニア向けの情報を記載しています。</p>
     <p>
       <TextLink href="https://speakerdeck.com/miyasho88/we-are-hiring">会社紹介資料を見る</TextLink>
     </p>

--- a/src/components/shared/TextLink.astro
+++ b/src/components/shared/TextLink.astro
@@ -1,0 +1,21 @@
+---
+export interface Props {
+  href?: string
+}
+
+const { href } = Astro.props
+---
+
+<a class="text-link" href={href}>
+  <slot />
+</a>
+
+<style>
+  .text-link {
+    color: var(--color-text-link);
+
+    &:hover {
+      text-decoration-line: none;
+    }
+  }
+</style>


### PR DESCRIPTION
## やったこと

会社紹介資料のセクションを追加

## 確認方法

- 見た目ふむふむ
- リンクをクリックして会社紹介資料の speaker deck に飛ぶこと

## キャプチャ

<img width="688" alt="image" src="https://github.com/kufu/hello-world/assets/11153463/239dcd37-f7de-4eb2-bc2a-9e23305886f6">
