### PR TITLE
header の表示がどの横幅でも崩れないようにする

### DIFF
--- a/src/components/sections/Header.astro
+++ b/src/components/sections/Header.astro
@@ -10,6 +10,7 @@ import SmartHRLogo from '../shared/SmartHRLogo.astro'
     <p class="headerNavRepository">/hello-world</p>
     <p class="headerNavText">プロダクトエンジニア採用</p>
   </div>
+
   <h1>歴史に残る<br />模範的なソフトウェアを作ろう</h1>
 </header>
 
@@ -18,7 +19,7 @@ import SmartHRLogo from '../shared/SmartHRLogo.astro'
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: .5rem;
+    gap: 0.5rem;
     padding-bottom: 1rem;
   }
 
@@ -26,7 +27,7 @@ import SmartHRLogo from '../shared/SmartHRLogo.astro'
     font-size: 1.5rem;
     font-weight: 700;
     font-family: DINAlternateBold;
-    padding-right: .5rem;
+    padding-right: 0.5rem;
   }
 
   .headerNavText {
@@ -38,5 +39,33 @@ import SmartHRLogo from '../shared/SmartHRLogo.astro'
     font-size: 6rem;
     line-height: 121%;
     letter-spacing: -0.06em;
+  }
+
+  @media screen and (max-width: 679px) {
+    .headerNavRepository {
+      font-size: 1.4rem;
+    }
+
+    .headerNavText {
+      font-size: 1.4rem;
+    }
+
+    h1 {
+      font-size: 13.4vw;
+    }
+  }
+
+  @media screen and (max-width: 599px) {
+    .headerNavWrapper {
+      font-size: 0.7rem;
+    }
+
+    .headerNavRepository {
+      font-size: 0.8rem;
+    }
+
+    .headerNavText {
+      font-size: 0.8rem;
+    }
   }
 </style>

--- a/src/components/sections/Header.astro
+++ b/src/components/sections/Header.astro
@@ -4,11 +4,11 @@ import SmartHRLogo from '../shared/SmartHRLogo.astro'
 
 <header>
   <div class="headerNavWrapper">
-    <a href="https://smarthr.co.jp/">
+    <a class="headerNavLogo" href="https://smarthr.co.jp/">
       <SmartHRLogo />
     </a>
     <p class="headerNavRepository">/hello-world</p>
-    <p class="headerNavText">プロダクトエンジニア採用</p>
+    <p>プロダクトエンジニア採用</p>
   </div>
 
   <h1>歴史に残る<br />模範的なソフトウェアを作ろう</h1>
@@ -21,17 +21,17 @@ import SmartHRLogo from '../shared/SmartHRLogo.astro'
     align-items: center;
     gap: 0.5rem;
     padding-bottom: 1rem;
+    font-size: 1.5rem;
+  }
+
+  .headerNavLogo {
+    font-size: 1rem;
   }
 
   .headerNavRepository {
-    font-size: 1.5rem;
     font-weight: 700;
     font-family: DINAlternateBold;
     padding-right: 0.5rem;
-  }
-
-  .headerNavText {
-    font-size: 1.5rem;
   }
 
   h1 {
@@ -42,11 +42,7 @@ import SmartHRLogo from '../shared/SmartHRLogo.astro'
   }
 
   @media screen and (max-width: 679px) {
-    .headerNavRepository {
-      font-size: 1.4rem;
-    }
-
-    .headerNavText {
+    .headerNavWrapper {
       font-size: 1.4rem;
     }
 
@@ -57,15 +53,11 @@ import SmartHRLogo from '../shared/SmartHRLogo.astro'
 
   @media screen and (max-width: 599px) {
     .headerNavWrapper {
+      font-size: 0.8rem;
+    }
+
+    .headerNavLogo {
       font-size: 0.7rem;
-    }
-
-    .headerNavRepository {
-      font-size: 0.8rem;
-    }
-
-    .headerNavText {
-      font-size: 0.8rem;
     }
   }
 </style>


### PR DESCRIPTION
## やりたいこと

「歴史に残る模範的なソフトウェアを作ろう」のテキストとその上部の細かいテキストが、横幅を狭くしても特に違和感のない表示にしたい

### やったこと

- media query でフォントサイズさげたりなど
- break point はバランス見て細かい数値入れている感じです
  - 特に SmartHR の一般に倣ってはいない

## キャプチャ

### Before

<img width="456" alt="image" src="https://github.com/kufu/hello-world/assets/11153463/70120c56-2106-464d-ba91-ba40b3cb4c5f">

### After

#### ある程度狭くしたとき

<img width="485" alt="image" src="https://github.com/kufu/hello-world/assets/11153463/e6d3e481-38f8-4252-9eea-ae296673fb9e">

#### iPhone SE のサイズの場合

<img width="387" alt="image" src="https://github.com/kufu/hello-world/assets/11153463/dc9138d7-dda7-4bb8-a2cc-202f412fe320">

#### さすがに狭くしすぎるとちょっと崩れるけどそこは気にしない

<img width="380" alt="image" src="https://github.com/kufu/hello-world/assets/11153463/0d8da222-f99b-4233-9b15-5ecc25ea98cd">

