### PR TITLE
外部リンクのバナー画像の対応

### DIFF
--- a/src/components/shared/MicroCMSContent.astro
+++ b/src/components/shared/MicroCMSContent.astro
@@ -34,5 +34,9 @@ const parsedContent = await convertMarkdownToHTML(content)
         color: var(--color-text-link);
       }
     }
+
+    & img {
+      width: 100%;
+    }
   }
 </style>

--- a/src/components/shared/MicroCMSContent.astro
+++ b/src/components/shared/MicroCMSContent.astro
@@ -36,7 +36,7 @@ const parsedContent = await convertMarkdownToHTML(content)
     }
 
     & img {
-      width: 100%;
+      max-width: 100%;
     }
   }
 </style>


### PR DESCRIPTION
外部リンクセクションの下部に人労打のバナーを配置することになったのでその対応。
`max-width: 100%;`を適用してコンテンツ幅を超過しないように制御した。

高さが大きすぎる画像に関する考慮等は特に入れていないが、現状はその手の画像を扱っていないので必要になった時にテコ入れをする。

![image](https://github.com/kufu/hello-world/assets/38499847/986643f4-7067-438f-ac26-598e74205053)
