### PR TITLE
コーポレートエンジニア & セキュリティエンジニアの求人リンクの有効化

### DIFF
--- a/src/components/parts/EntrySection.tsx
+++ b/src/components/parts/EntrySection.tsx
@@ -82,15 +82,11 @@ export const EntrySection = () => (
             QAエンジニア（リーダー候補）
           </Item>
         </li>
-        {/* MEMO: 募集停止中
         <li>
           <Item href="https://open.talentio.com/1/c/smarthr/requisitions/detail/7587" target="_blank" rel="noopener noreferrer">
             コーポレートエンジニア
-            <BrSp />
-            <span>（情報システム エンジニア）</span>
           </Item>
         </li>
-        */}
         {/* MEMO: 募集停止中
         <li>
           <Item href="https://open.talentio.com/1/c/smarthr/requisitions/detail/13859" target="_blank" rel="noopener noreferrer">

--- a/src/components/parts/EntrySection.tsx
+++ b/src/components/parts/EntrySection.tsx
@@ -87,13 +87,11 @@ export const EntrySection = () => (
             コーポレートエンジニア
           </Item>
         </li>
-        {/* MEMO: 募集停止中
         <li>
           <Item href="https://open.talentio.com/1/c/smarthr/requisitions/detail/13859" target="_blank" rel="noopener noreferrer">
             セキュリティエンジニア
           </Item>
         </li>
-        */}
         <li>
           <Item href="https://open.talentio.com/1/c/smarthr/requisitions/detail/13762" target="_blank" rel="noopener noreferrer">
             カジュアル面談ご希望の方


### PR DESCRIPTION
## やりたいこと & やったこと

情シスセキュリティの以下の2求人が再オープンしたので、リンクを有効化したいです。

- コーポレートエンジニア
- セキュリティエンジニア

## やったこと

求人クローズに伴いコメントアウトしていた部分を戻しました。
「情報システムエンジニア」という名称は今回は使わないため、削除しています。
