### PR TITLE
求人名の変更に追従したい

### DIFF
--- a/src/components/parts/EntrySection.tsx
+++ b/src/components/parts/EntrySection.tsx
@@ -62,7 +62,9 @@ export const EntrySection = () => (
         </li>
         <li>
           <Item href="https://open.talentio.com/r/1/c/smarthr/pages/75921" target="_blank" rel="noopener noreferrer">
-            プラットフォーム開発エンジニア（バックエンド）
+            ウェブアプリケーションエンジニア
+            <BrPc />
+            （プラットフォーム領域 バックエンド）
           </Item>
         </li>
         {/* MEMO: 募集停止中


### PR DESCRIPTION
求人票の名前が掲載後に変更されているので、リンク名も追従したいです！
[ウェブアプリケーションエンジニア（プラットフォーム領域 バックエンド） / 株式会社SmartHR](https://open.talentio.com/r/1/c/smarthr/pages/75921)

| 変更前 | 変更後 |
| --- | --- |
| ![image](https://github.com/kufu/hello-world/assets/24504765/8bbf564d-c58a-4afc-bac9-ba0a6c541770) | ![image](https://github.com/kufu/hello-world/assets/24504765/64daa4c0-57ea-423c-8a2d-03105827577b) |

