### PR TITLE
[renewal] 会社紹介資料をテキストリンクではなく iframe 埋め込みにする

### DIFF
--- a/src/components/sections/Document.astro
+++ b/src/components/sections/Document.astro
@@ -10,7 +10,15 @@ import TextLink from '../shared/TextLink.astro'
       SmartHRの全職種向け採用資料です。エンジニア採用サイトには、この資料では触れられていないエンジニア向けの情報を記載しています。
     </p>
     <p>
-      <TextLink href="https://speakerdeck.com/miyasho88/we-are-hiring">会社紹介資料を見る</TextLink>
+      <iframe
+        class="speakerdeck-iframe"
+        frameborder="0"
+        src="https://speakerdeck.com/player/e20c6467299e4c1ca07ad14064a89d74"
+        title="SmartHR会社紹介資料  / We are hiring"
+        allowfullscreen="true"
+        style="border: 0px; background: padding-box padding-box rgba(0, 0, 0, 0.1); margin: 0px; padding: 0px; border-radius: 6px; box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 40px; width: 100%; height: auto; aspect-ratio: 560 / 315;"
+        data-ratio="1.7777777777777777"
+      ></iframe>
     </p>
   </Stack>
 </SectionWrapper>


### PR DESCRIPTION
会社紹介資料をテキストリンクから iframe 埋め込みに変更しました

### before
<img width="894" alt="スクリーンショット 2023-11-08 21 38 03" src="https://github.com/kufu/hello-world/assets/34148798/9808fa9b-137c-4c21-aefa-3a006541603a">

### after
<img width="894" alt="スクリーンショット 2023-11-08 21 38 35" src="https://github.com/kufu/hello-world/assets/34148798/e11caf3b-e546-4653-bbd7-406ad1944cfa">

### その他メモ
ouji san には以下のスレで確認済みで、デザイン的には問題なし
https://kufuinc.slack.com/archives/C04PPFBGQHW/p1699433051770999

### 悩んだポイント
元の TextLink をそのまま SpeakerDeck の iframe タグに置き換えただけなのですが、それで問題ないのかわからず…
