### PR TITLE
環境変数に関する修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ pnpm-debug.log*
 # environment variables
 .env
 .env.production
-.env.development
+.env.local
 
 # macOS-specific files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -20,16 +20,17 @@ Welcome to...
 
 ## Setup
 
-### 環境変数
+### 環境変数 (社内向け)
 
-`.env`ファイルをコピーして`.env.development`ファイルを作成してください。
+`.env`ファイルをコピーして`.env.local`ファイルを作成してください。
 その後、それぞれ必要な値を設定してください。
 
 #### SECRET_MICROCMS_KEY
 
-[hello-world Manage API Keys | microCMS](https://smarthr-hello-world.microcms.io/api-keys)からAPIキーを取得できます
+1passwordのDev保管庫に`hello-world MicroCMS API Key`としてAPI Keyを格納してあるのでそちらを参照してください
 
 ### 起動コマンド
+
 ```
 $ yarn install
 $ yarn dev

--- a/src/services/microcms/index.ts
+++ b/src/services/microcms/index.ts
@@ -10,7 +10,7 @@ const API_ENDPOINT = 'contents'
 
 const client = createClient({
   serviceDomain: SERVICE_DOMAIN,
-  apiKey: import.meta.env.SECRET_MICROCMS_KEY,
+  apiKey: import.meta.env.SECRET_MICROCMS_KEY || 'key',
 })
 
 // コンテンツ種別をもとにコンテンツを取得する


### PR DESCRIPTION
以下の対応を追加

- README修正
  - 環境変数の設定に関しては社内向けの内容であることを明記
  - API Keyを1passwordから参照してもらうよう手順を修正
- 実装の修正
  - API Keyを.env.loaclになにかしら入力しないとローカル起動時に画面表示できなくなっていたので修正
  - envファイルに値が入っていない（undefined）場合にエラーが置きていたのでclient生成時に環境変数が取得出来なかった場合ダミーテキストを入れるようにした
  - この場合、外部リンクエリアには何のコンテンツも表示されないようになります

![image](https://github.com/kufu/hello-world/assets/38499847/0de57319-a934-4486-b194-31e29e9edd3a)
