### PR TITLE
Pull Requestに対してlintを実行するGitHub Actionsを導入

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: lint
+
+on:
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
+      - name: Install Dependency
+        run: yarn --frozen-lockfile
+      - name: lint
+        run: yarn lint

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prettier-plugin-astro": "^0.12.0",
     "stylelint": "^15.11.0",
     "stylelint-config-prettier": "^9.0.5",
-    "stylelint-config-standard": "^36.0.0",
+    "stylelint-config-standard": "^34.0.0",
     "typescript": "^5.3.3"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>kufu/renovate-config"
+    "github>kufu/renovate-config",
+    "helpers:pinGitHubActionDigests"
   ],
-  "enabledManagers": ["npm"],
+  "enabledManagers": ["github-actions", "npm"],
   "npm": {
     "rangeStrategy": "bump",
     "packageRules": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5135,17 +5135,17 @@ stylelint-config-prettier@^9.0.5:
   resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-9.0.5.tgz#9f78bbf31c7307ca2df2dd60f42c7014ee9da56e"
   integrity sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==
 
-stylelint-config-recommended@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz#b395c7014838d2aaca1755eebd914d0bb5274994"
-  integrity sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==
+stylelint-config-recommended@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz#c48a358cc46b629ea01f22db60b351f703e00597"
+  integrity sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==
 
-stylelint-config-standard@^36.0.0:
-  version "36.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-36.0.0.tgz#6704c044d611edc12692d4a5e37b039a441604d4"
-  integrity sha512-3Kjyq4d62bYFp/Aq8PMKDwlgUyPU4nacXsjDLWJdNPRUgpuxALu1KnlAHIj36cdtxViVhXexZij65yM0uNIHug==
+stylelint-config-standard@^34.0.0:
+  version "34.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz#309f3c48118a02aae262230c174282e40e766cf4"
+  integrity sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==
   dependencies:
-    stylelint-config-recommended "^14.0.0"
+    stylelint-config-recommended "^13.0.0"
 
 stylelint@^15.11.0:
   version "15.11.0"


### PR DESCRIPTION
## 概要
静的解析ツールは導入されているが、CIが導入されていなかった 😭 
これじゃあ、警告やエラーが出てても気付けないよ・・・

このPRでは、GitHub Actionsを導入してPull Requestに対して静的解析を実行するようにします。

## やったこと
* GitHub Actionsの導入
  * 内部では `yarn lint`を実行しています
* `stylelint-config-standard`を v36.0.0 -> v34.0.0にダウングレード
  * v36.0.0はstylelintのv16.1.0以上が必要
  * しかし、現在stylekintはv15系を使っている
  * アップデートのコストを考え、stylelint v15系が利用できるv34.0.0にダウングレードしました
* renovateでGitHub Actionsもアップデートするようにした