### PR TITLE
埋め込みmiroをfigmaに変更

### DIFF
--- a/src/components/sections/OrganizationalStructure.astro
+++ b/src/components/sections/OrganizationalStructure.astro
@@ -7,12 +7,10 @@ import Stack from '../shared/Stack.astro';
   <Stack>
     <p>SmartHR開発組織の構造や開発プロセスなどをご紹介します。</p>
     <iframe
-      width="100%"
-      height="432"
-      src="https://miro.com/app/embed/uXjVMhWKJjw=/?embedId=954898660000&autoplay=yep"
-      frameborder="0"
-      scrolling="no"
-      allow="fullscreen; clipboard-read; clipboard-write"
+      style="border: 1px solid rgba(0, 0, 0, 0.1);"
+      width="800"
+      height="450"
+      src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FHFNrUtz5Bf1c52YABCxxrY%2FSmartHR-%25E9%2596%258B%25E7%2599%25BA%25E7%25B5%2584%25E7%25B9%2594%25E3%2581%25AB%25E3%2581%25A4%25E3%2581%2584%25E3%2581%25A6%3Ftype%3Dwhiteboard%26node-id%3D0%253A1%26t%3DThtbWzDUnnJKDUeP-1"
       allowfullscreen></iframe>
   </Stack>
 </ContentBox>


### PR DESCRIPTION
「開発組織について」で埋め込まれてるmiroをfigmaに差し替えました。

差し替え先figma
https://www.figma.com/file/HFNrUtz5Bf1c52YABCxxrY/SmartHR-%E9%96%8B%E7%99%BA%E7%B5%84%E7%B9%94%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6?type=whiteboard&node-id=0%3A1&t=e01c3ZZ1qD628mY3-1

figma（figjam）の都合上、
- Readonlyで全体公開
- SmartHRアカウント持ちだけ編集可能

みたいなことができないらしく、編集権限つけるには
- 個別でつける
- 公開プロジェクト権限を付ける

のどちらかが必要になります。現時点ではどちらもやってないので、もしfigmaの内容に不備がありそうだったら修正するのでご指摘ください。

初期表示の倍率とかその辺弄る方法探してみたんですが見当たらず、とりあえずデフォルトのままになってます。
このままでもいいかな…と思ってはいますが、もし変更したほうがいいなどあれば、やり方ご存知であればぜひ…