### PR TITLE
アクセス直後にヘッダががたつく問題を修正

### DIFF
--- a/src/layouts/Head.astro
+++ b/src/layouts/Head.astro
@@ -1,3 +1,7 @@
+---
+import font from '/fonts/DINAlternate-Bold.woff';
+---
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width" />
@@ -22,6 +26,13 @@
   <meta name="twitter:title" content="SmartHR エンジニア採用" />
   <meta name="twitter:site" content="@SmartHR_jp" />
   <link rel="icon" href="/favicon/favicon.ico" />
+  <link
+      rel="preload"
+      as="font"
+      href={font}
+      type="font/woff2"
+      crossorigin
+  />
   <link
     rel="apple-touch-icon"
     sizes="180x180"


### PR DESCRIPTION
## 概要

サイトにアクセスしたときにヘッダーの「/hello-world」が表示されず、少し遅れて「/hello-world」が表示されます。ブラウザーの開発者ツールでキャッシュを切っておくと確認しやすいです。

<img width="300" alt="image" src="https://github.com/user-attachments/assets/cab9cd1f-2ebc-413c-a841-844eb0764f9d" />

↓

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b64c0c28-4757-409b-be0a-9f3a35c0e831" />

フォントの読み込みで待たされているのが原因のようです。

```
  @font-face {
    font-family: DINAlternateBold;
    src: url('/fonts/DINAlternate-Bold.woff') format('woff');
  }
```

## 変更内容

別のフォントを代替表示することも考えたのですが試してみると違和感が大きかったので、フォントのファイル読み込みタイミングを早めることで対処しました。

### 改修前

<img width="500" alt="Screenshot 2025-02-08 at 18 36 11" src="https://github.com/user-attachments/assets/b7992152-abfe-4d22-a3f4-7c49ccccd434" />

### 改修後

<img width="500" alt="image" src="https://github.com/user-attachments/assets/0f5b755c-bfe7-46b3-b9f4-e5287e3c5a9c" />

## 確認方法

ローカルで確認する場合、一度ビルドしてその内容をWebサーバーを通して参照してください。ブラウザーの開発者ツールでキャッシュを切った状態でリロードを繰り返しても文字がほとんどガタガタしないようになっているはずです。