### PR TITLE
renovateの設定からyarn用のpostUpdateOptionsを削除し、pnpmDedupeを追加する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>kufu/renovate-config",
-    "helpers:pinGitHubActionDigests"
-  ],
+  "extends": ["github>kufu/renovate-config", "helpers:pinGitHubActionDigests"],
   "enabledManagers": ["github-actions", "npm"],
   "npm": {
     "rangeStrategy": "bump",
@@ -13,7 +10,7 @@
         "matchUpdateTypes": ["minor", "patch"],
         "automerge": true
       }
-    ]
-  },
-  "postUpdateOptions": ["pnpmDedupe"]
+    ],
+    "postUpdateOptions": ["pnpmDedupe"]
+  }
 }


### PR DESCRIPTION
## 概要
renovateの設定からyarn用のpostUpdateOptionsを削除し、pnpmDedupeを追加する

## 背景
このプロジェクトはpnpmを使用しているにも関わらず、Yarn専用のyarnDedupeHighestオプションが設定されていました。
pnpm用のpnpmDedupeに変更しました。

## 変更内容
* renovate.jsonを"postUpdateOptions": ["pnpmDedupe"]に変更