### PR TITLE
求人のグルーピングに対応するsytleの追加

### DIFF
--- a/src/components/shared/MicroCMSContent.astro
+++ b/src/components/shared/MicroCMSContent.astro
@@ -23,7 +23,7 @@ const parsedContent = await convertMarkdownToHTML(content);
   .microcms-content-wrapper {
     display: flex;
     flex-direction: column;
-    gap: 1.8rem;
+    gap: 0.75rem;
 
     /* [リンクテキスト](https://example.com) の構文に対するスタイル */
     & a {
@@ -38,6 +38,11 @@ const parsedContent = await convertMarkdownToHTML(content);
 
     & img {
       max-width: 100%;
+    }
+    & h4 {
+      font-weight: bold;
+      font-size: 1.25rem;
+      margin-top: var(--space-s);
     }
   }
 </style>


### PR DESCRIPTION
## やりたいこと
- 求人を領域ごとにグルーピングした際の見出しにstyleを当てたい

## やったこと
- h4に対応するstyleを追加
- gapの調整

## スクショ
ローカルで試したスクショ
<img width="1586" height="1291" alt="image" src="https://github.com/user-attachments/assets/4e5cfce5-9a25-4a86-bfdb-48d21cee13ed" />
